### PR TITLE
NOCARD Add command line option to test statsbot

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Protolude
 import qualified Data.Text as T
 import Statsbot
-import System.IO
+import System.IO (BufferMode(..), hSetBuffering)
 
 main :: IO ()
 main = do
@@ -12,4 +12,5 @@ main = do
     reportFile <- maybe (print "You must provide a report .yaml file" *> exitFailure)
                         pure $
                         head args
-    runStatsbot reportFile
+    let testMode = "--test" `elem` args
+    runStatsbot reportFile testMode

--- a/src/Statsbot.hs
+++ b/src/Statsbot.hs
@@ -13,15 +13,18 @@ import Statsbot.Types
 
 runStatsbot ::
     FilePath
+    -> Bool
     -> IO ()
-runStatsbot configFilePath = do
+runStatsbot configFilePath testMode = do
     loaderResults <- loadRowConfigurations configFilePath
     config <- case loaderResults of
                 Right rows -> pure rows
                 Left (ConfigLoadError err) -> putStrLn err *>  exitFailure
     rows <- mapM toReportRow $ rows config
     let body = prettySlackReport (reportTitle config) (historyWindowDays config) rows
-    publishReport (targetURL config) (reportTitle config) body
+    if testMode
+        then putStrLn body
+        else publishReport (targetURL config) (reportTitle config) body
 
 toReportRow (Row t l m) = do
     evaluated <- evaluateSource m


### PR DESCRIPTION
Adds a `--test` option for testing the output in the console.

```
11:39 $ WAREHOUSE_CONNECTION=$(confcrypt aws get -n WAREHOUSE_CONNECTION ../app/statsbot/config.econf) stack exec statsbot /Users/marc.cordova/dev/app/statsbot/daily_product.yaml --test
```Metric                    Yesterday    Past 30-day median    Details                   
Signups                   2837.0       1692.0                https://bit.ly/31XkQa8
Sessions                  15392.0      10544.0               https://bit.ly/3mGHaNf
Essays Submitted          159.0        135.0                 https://bit.ly/3jIAv3h
Paid Essay Submissions    8.0          13.0                  https://bit.ly/3jIAv3h
Distinct LS users         294.0        150.0                 https://bit.ly/3mAibuT
Community posts           8.0          8.0                   https://bit.ly/3mAibuT
Returning users           7922.0       5838.0                https://bit.ly/37WfYWo
Accounts deleted          18.0         18.0                  https://bit.ly/3I6NzwC```
```
